### PR TITLE
Hides Avatar Alt when img is not loaded yet

### DIFF
--- a/src/components/Common/AvatarPlaceholder.jsx
+++ b/src/components/Common/AvatarPlaceholder.jsx
@@ -5,12 +5,10 @@ import { buildAvatarClass } from 'utils/buildAvatarClass';
 import { useSelector } from 'react-redux';
 import { getUserPhotoFromFb } from 'selectors/firebase/profile/getUserPhotoFromFb';
 import { avatarPlaceholderSize } from 'consts/avatarPlaceholderSizes';
-import { getDisplayNameFromFb } from 'selectors/firebase/profile/getDisplayNameFromFb';
 
 export const AvatarPlaceholder = ({
   id, className, size, onClick, onKeyDown
 }) => {
-  const userFullName = useSelector(getDisplayNameFromFb);
   const userPhotoURL = useSelector(getUserPhotoFromFb);
 
   return (
@@ -27,7 +25,7 @@ export const AvatarPlaceholder = ({
     >
       {userPhotoURL && (
         <img
-          alt={`${userFullName} avatar`}
+          alt="User avatar"
           className="avatarPlaceholder_image"
           src={userPhotoURL}
         />

--- a/src/styles/avatarPlaceholder.scss
+++ b/src/styles/avatarPlaceholder.scss
@@ -27,6 +27,9 @@ $avatarPlaceholder-sizes: (
     width: 100%;
     height: 100%;
     border-radius: 50%;
+    // https://stackoverflow.com/questions/12667926/hide-alt-tag-in-firefox
+    // color - transparent hides alt when img is loading
+    color: transparent;
   }
 
   @each $size-key, $size-value in $avatarPlaceholder-sizes {


### PR DESCRIPTION
## Problem
Firefox displays alt text before rendering any img. The avatarPlaceholder has a weird behavior while fetching User's image from Firebase.

## Solution
The trick was as easy as setting the color to `transparent`

## Screenshot

| BEFORE | AFTER |
|---------|---------|
| ![2020-06-05 00 55 24](https://user-images.githubusercontent.com/29388744/83818765-71bb6d00-a6c8-11ea-8472-473c95c17b7a.gif) | ![2020-06-05 00 49 35](https://user-images.githubusercontent.com/29388744/83818791-80098900-a6c8-11ea-8445-8be9376a6615.gif) |