### PR TITLE
Fixes Account Profile Broken Styles

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -32,6 +32,7 @@ $mq-breakpoints: (
 @import './settingsSidebar';
 @import './profile';
 @import './profileForm';
+@import './accountForm';
 @import './settingsInputField';
 @import './settingsChooseFileField';
 @import './settingsTextAreaField';


### PR DESCRIPTION
## What's the problem?
Account Settings page is missing styles

## What was done?
Adding the proper style sheet fixed the issue.

## Screenshots

| BEFORE | AFTER |
|---------|---------|
| <img width="836" alt="Screenshot 2020-06-06 at 23 52 44" src="https://user-images.githubusercontent.com/29388744/83955849-bb868d80-a857-11ea-859a-6fb75f7f8e47.png"> | <img width="872" alt="Screenshot 2020-06-06 at 23 52 12" src="https://user-images.githubusercontent.com/29388744/83955877-17511680-a858-11ea-9f97-2f9dc7dce2ce.png"> |